### PR TITLE
make Replicate API host configurable

### DIFF
--- a/pages/api/predictions/[id].js
+++ b/pages/api/predictions/[id].js
@@ -1,13 +1,14 @@
+const API_HOST = process.env.REPLICATE_API_HOST || "https://api.replicate.com";
+
+console.log({ API_HOST });
+
 export default async function handler(req, res) {
-  const response = await fetch(
-    "https://api.replicate.com/v1/predictions/" + req.query.id,
-    {
-      headers: {
-        Authorization: `Token ${process.env.REPLICATE_API_TOKEN}`,
-        "Content-Type": "application/json",
-      },
-    }
-  );
+  const response = await fetch(`${API_HOST}/v1/predictions/${req.query.id}`, {
+    headers: {
+      Authorization: `Token ${process.env.REPLICATE_API_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+  });
   if (response.status !== 200) {
     let error = await response.json();
     res.statusCode = 500;

--- a/pages/api/predictions/index.js
+++ b/pages/api/predictions/index.js
@@ -1,3 +1,4 @@
+const API_HOST = process.env.REPLICATE_API_HOST || "https://api.replicate.com";
 const addBackgroundToPNG = require("lib/add-background-to-png");
 
 export default async function handler(req, res) {
@@ -18,7 +19,7 @@ export default async function handler(req, res) {
     input: req.body,
   });
 
-  const response = await fetch("https://api.replicate.com/v1/predictions", {
+  const response = await fetch(`${API_HOST}/v1/predictions`, {
     method: "POST",
     headers: {
       Authorization: `Token ${process.env.REPLICATE_API_TOKEN}`,


### PR DESCRIPTION
This change allows inpainter to be configured to point at a different API host using the `REPLICATE_API_HOST` env var.